### PR TITLE
restore process.cwd() after symlinking

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ function SymlinkWebpackPlugin (config = []) {
         const originPath = path.join(outputPath, option.origin);
 
         if (fs.existsSync(originPath)) {
-          const baseDir = __dirname;
+          const baseDir = process.cwd();
           process.chdir(outputPath);
           const symlink = path.join(outputPath, option.symlink);
           const origin = path.relative(path.dirname(symlink), originPath);

--- a/test/index.js
+++ b/test/index.js
@@ -56,4 +56,16 @@ describe('SymlinkWebpackPlugin', () => {
       });
     });
   });
+
+  it('should not pollute process.cwd()', (done) => {
+      const cwd = process.cwd();
+
+      const plugin = new SymlinkWebpackPlugin(
+        [{ origin: 'app.js', symlink: 'symlink.js' }]
+      );
+      webpack(webpackOption(plugin)).run((err, stats) => {
+        expect(process.cwd()).to.eq(cwd);
+        done();
+      });
+  });
 });


### PR DESCRIPTION
Fixes #1 , and adds a test to ensure that the plugin doesn't leave process.cwd() in a bad state.