### PR TITLE
Add an optional “force” parameter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
-function SymlinkWebpackPlugin (config = []) {
+function SymlinkWebpackPlugin (config = [], force = false) {
 
   let options;
   if (config instanceof Array) {
@@ -16,7 +16,7 @@ function SymlinkWebpackPlugin (config = []) {
         const outputPath = compiler.options.output.path;
         const originPath = path.join(outputPath, option.origin);
 
-        if (fs.existsSync(originPath)) {
+        if (fs.existsSync(originPath) || force) {
           const baseDir = process.cwd();
           process.chdir(outputPath);
           const symlink = path.join(outputPath, option.symlink);

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,11 @@ function SymlinkWebpackPlugin (config = [], force = false) {
           const symlink = path.join(outputPath, option.symlink);
           const origin = path.relative(path.dirname(symlink), originPath);
 
-          if (fs.existsSync(symlink)) fs.unlinkSync(symlink);
+            if (force) {
+                fs.unlinkSync(symlink);
+            } else {
+                if (fs.existsSync(symlink)) fs.unlinkSync(symlink);
+            }
           fs.symlinkSync(origin, symlink);
 
           process.chdir(baseDir);


### PR DESCRIPTION
I'm using a webpack plugin that generates assets that won't exist when the `symlink-webpack-plugin` is executed, so I added an optional `force` parameter:

```
                new SymlinkWebpackPlugin(
                    [
                          { origin: 'index.html', symlink: '200.html' },
                          { origin: 'index.html', symlink: '404.html' },
                    ],
                    true
                ),
```

The parameter defaults to `false` so the current behavior is kept for any existing projects that don't pass it in. This simply causes it to skip the check for the existence of the file it's symlinking to, and since `fs.existsSync(symlink)` will return `false` if the symlink exists, but the file it's linking to does not, we skip that check as well.