### PR TITLE
Windows support

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ class SymlinkWebpackPlugin {
         } catch (e) {
           // symlink doesn't exist
         } finally {
-          symlinkSync(origin, symlink);
+          symlinkSync(origin, symlink, 'junction');
         }
 
         process.chdir(baseDir);


### PR DESCRIPTION
For some reason Windows still not allowing creating symlinks for non-administrators, so 'junction' type of symlink is added (ignored on other platforms) as documented: https://nodejs.org/api/fs.html#fs_fs_symlink_target_path_type_callback